### PR TITLE
Updated reference_date dimension

### DIFF
--- a/bigquery/views/method_8.view.lkml
+++ b/bigquery/views/method_8.view.lkml
@@ -155,7 +155,7 @@ parameter: over_period_type {
 #convert_tz: no
 #type: nothing <-- just right
     sql: DATE_TRUNC(
-    DATE_ADD({% date_end pop.date_filter %}, INTERVAL 0 - ${within_periods.n} {% parameter pop.within_period_type %})
+    DATE_ADD(DATE({% date_end pop.date_filter %}), INTERVAL 0 - ${within_periods.n} {% parameter pop.within_period_type %})
     , {% parameter pop.within_period_type %});;
   }
 


### PR DESCRIPTION
The {% date_end pop.date_filter %} liquid variable was not wrapped in a DATE() function which causes it to error when you try to select the formatted version of the field in an explore.